### PR TITLE
[Feature] Field & Option Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Instead of fetching data with `get_field` and `get_sub_field` you can use the `f
 echo field('title');
 ```
 
-> **Note:** This will not work if two fields in field group share the same name.
+> **Note:** This will not work if two fields in a field group share the same name.
 
 #### Option
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ acf_page([
 ]);
 ```
 
+## Theming
+
+This package provides two helpers to make theming with custom fields much cleaner.
+
+#### Field
+
+Instead of fetching data with `get_field` and `get_sub_field` you can use the `field` helper function. It works as the `get_field` function except that if checks if the given field name is a sub field first.
+
+> **Note:** This will not work if two fields in field group share the same name.
+
+```php
+echo field('title');
+```
+
+#### Option
+
+Instead of passing the `option` key to the `get_field` function we can now use the new option function. It will automagically add the `option` key to the `get_field` function.
+
+```php
+echo option('github-url');
+```
+
 ## Resources
 
 Below you'll find a list of articles which can help you getting started and advance your custom fields knowledge.

--- a/README.md
+++ b/README.md
@@ -12,15 +12,6 @@ If you're working with multiple developers on a WordPress application with custo
 [![Latest Version](https://img.shields.io/github/release/wordplate/acf.svg?style=flat)](https://github.com/wordplate/acf/releases)
 [![License](https://img.shields.io/packagist/l/wordplate/acf.svg?style=flat)](https://packagist.org/packages/wordplate/acf)
 
-#### Contents
-
-- [Installation](#installation)
-- [Usage](#usage)
-- [Settings](#settings)
-- [Helpers](#helpers)
-- [Theming](#theming)
-- [Resources](#resources)
-
 ## Installation
 
 Require this package, with [Composer](https://getcomposer.org/), in the root directory of your project.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ If you're working with multiple developers on a WordPress application with custo
 [![Latest Version](https://img.shields.io/github/release/wordplate/acf.svg?style=flat)](https://github.com/wordplate/acf/releases)
 [![License](https://img.shields.io/packagist/l/wordplate/acf.svg?style=flat)](https://packagist.org/packages/wordplate/acf)
 
+#### Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Settings](#settings)
+- [Helpers](#helpers)
+- [Theming](#theming)
+- [Resources](#resources)
+
 ## Installation
 
 Require this package, with [Composer](https://getcomposer.org/), in the root directory of your project.

--- a/README.md
+++ b/README.md
@@ -188,15 +188,15 @@ This package provides two helpers to make theming with custom fields much cleane
 
 Instead of fetching data with `get_field` and `get_sub_field` you can use the `field` helper function. It works as the `get_field` function except that if checks if the given field name is a sub field first.
 
-> **Note:** This will not work if two fields in field group share the same name.
-
 ```php
 echo field('title');
 ```
 
+> **Note:** This will not work if two fields in field group share the same name.
+
 #### Option
 
-Instead of passing the `option` key to the `get_field` function we can now use the new option function. It will automagically add the `option` key to the `get_field` function.
+Instead of passing the `option` key to the `get_field` function we can now use the new option function. It will automagically use the `get_field` function with the `option` key.
 
 ```php
 echo option('github-url');

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -689,10 +689,10 @@ if (!function_exists('field')) {
             return;
         }
 
-        $value = get_field($name, $post);
+        $value = get_sub_field($name);
 
         if (!$value) {
-            $value = get_sub_field($name);
+            $value = get_field($name, $post);
         }
 
         return empty($value) ? null : $value;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -673,3 +673,24 @@ if (!function_exists('acf_oembed')) {
         return new Field($settings, ['name']);
     }
 }
+
+if (!function_exists('field')) {
+    /**
+     * Shorthand getter for the fields and sub fields functions.
+     *
+     * @param string $key
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    function field(string $key, $default = null)
+    {
+        if (!function_exists('get_field')) {
+            return $default;
+        }
+
+        $value = get_field($key);
+
+        return empty($value) ? $default : $value;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -678,19 +678,43 @@ if (!function_exists('field')) {
     /**
      * Shorthand getter for the fields and sub fields functions.
      *
-     * @param string $key
-     * @param mixed $default
+     * @param string $name
+     * @param int|\WP_Post|null $post
      *
      * @return mixed
      */
-    function field(string $key, $default = null)
+    function field(string $name, $post = null)
     {
         if (!function_exists('get_field')) {
-            return $default;
+            return;
         }
 
-        $value = get_field($key);
+        $value = get_field($name, $post);
 
-        return empty($value) ? $default : $value;
+        if (!$value) {
+            $value = get_sub_field($name);
+        }
+
+        return empty($value) ? null : $value;
+    }
+}
+
+if (!function_exists('option')) {
+    /**
+     * Shorthand getter for the field option function.
+     *
+     * @param string $name
+     *
+     * @return mixed
+     */
+    function option(string $name)
+    {
+        if (!function_exists('get_field')) {
+            return;
+        }
+
+        $value = get_field($name, 'option');
+
+        return empty($value) ? null : $value;
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -193,8 +193,9 @@ class HelpersTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testFieldMissingFunction()
+    public function testMissingGetFieldFunction()
     {
-        $this->assertNull(field('title'));
+        $this->assertNull(field('field'));
+        $this->assertNull(option('option'));
     }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -174,4 +174,27 @@ class HelpersTest extends TestCase
     {
         $this->assertNull(acf_page([]));
     }
+
+    public function testField()
+    {
+        require __DIR__.'/stubs/functions.php';
+
+        $this->assertSame('marty', field('marty', 11));
+        $this->assertNull(field('marty'));
+    }
+
+    public function testOption()
+    {
+        require __DIR__.'/stubs/functions.php';
+
+        $this->assertSame('marty', option('marty'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testFieldMissingFunction()
+    {
+        $this->assertNull(field('title'));
+    }
 }

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -175,6 +175,9 @@ class HelpersTest extends TestCase
         $this->assertNull(acf_page([]));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testField()
     {
         require __DIR__.'/stubs/functions.php';
@@ -183,6 +186,9 @@ class HelpersTest extends TestCase
         $this->assertNull(field('marty'));
     }
 
+    /**
+     * @runInSeparateProcess
+     */
     public function testOption()
     {
         require __DIR__.'/stubs/functions.php';

--- a/tests/stubs/functions.php
+++ b/tests/stubs/functions.php
@@ -28,7 +28,9 @@ if (!function_exists('acf_add_options_page')) {
 if (!function_exists('get_field')) {
     function get_field($value, $post = null)
     {
-        return $post && $value !== 'option' ? $value : null;
+        if ($post && $value !== 'option') {
+            return $value;
+        }
     }
 }
 

--- a/tests/stubs/functions.php
+++ b/tests/stubs/functions.php
@@ -28,7 +28,7 @@ if (!function_exists('acf_add_options_page')) {
 if (!function_exists('get_field')) {
     function get_field($value, $post = null)
     {
-        if ($post) {
+        if ($post && $value !== 'option') {
             return $value;
         }
     }

--- a/tests/stubs/functions.php
+++ b/tests/stubs/functions.php
@@ -28,11 +28,7 @@ if (!function_exists('acf_add_options_page')) {
 if (!function_exists('get_field')) {
     function get_field($value, $post = null)
     {
-        if ($post && $value !== 'option') {
-            return $value;
-        }
-
-        return;
+        return $post && $value !== 'option' ? $value : null;
     }
 }
 

--- a/tests/stubs/functions.php
+++ b/tests/stubs/functions.php
@@ -24,3 +24,19 @@ if (!function_exists('acf_add_options_page')) {
         //
     }
 }
+
+if (!function_exists('get_field')) {
+    function get_field($value, $post = null)
+    {
+        if ($post) {
+            return $value;
+        }
+    }
+}
+
+if (!function_exists('get_sub_field')) {
+    function get_sub_field()
+    {
+        //
+    }
+}

--- a/tests/stubs/functions.php
+++ b/tests/stubs/functions.php
@@ -31,6 +31,8 @@ if (!function_exists('get_field')) {
         if ($post && $value !== 'option') {
             return $value;
         }
+
+        return;
     }
 }
 


### PR DESCRIPTION
This will request will add two shorthand helper functions for fetching field data in the view files.

The field function will first fetch data from the `get_field` function and then if it is null check the `get_sub_field` function if the current field is a sub field.

```php
echo get_field('name'); // Before
echo field('name'); // After
```

The option function will basically just use the `get_field` function behind the scenes and add the 'option' key automagically.

```php
echo get_field('name', 'option'); // Before
echo option('name'); // After
```

If you've any suggestion or ideas, please let me know!