### PR TITLE
Add is_layout helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Instead of using [`get_row_layout`](https://www.advancedcustomfields.com/resourc
 
 ```php
 if (is_layout('text')) {
-    //
+    // Load the layout row template view.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,14 @@ acf_layout([
 ]);
 ```
 
+Instead of using [`get_row_layout`](https://www.advancedcustomfields.com/resources/get_row_layout) and compare it against a string you may use the `is_layout` function.
+
+```php
+if (is_layout('text')) {
+    //
+}
+```
+
 ### Location
 
 The location function help you write [custom location rules](https://www.advancedcustomfields.com/resources/custom-location-rules) without the `name`, `operator` and `value` keys.

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -699,6 +699,20 @@ if (!function_exists('field')) {
     }
 }
 
+if (!function_exists('is_layout')) {
+    /**
+     * Check whether current row is layout.
+     *
+     * @param string $layout
+     *
+     * @return bool
+     */
+    function is_layout(string $layout): bool
+    {
+        return get_row_layout() === $layout;
+    }
+}
+
 if (!function_exists('option')) {
     /**
      * Shorthand getter for the field option function.

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -151,6 +151,11 @@ class HelpersTest extends TestCase
         $this->assertSame($location, acf_location('page_template', '!=', 'templates/start-page.php'));
     }
 
+    public function testIsLayout()
+    {
+        $this->assertTrue(is_layout('text'));
+    }
+
     /**
      * @runInSeparateProcess
      */

--- a/tests/stubs/helpers.php
+++ b/tests/stubs/helpers.php
@@ -15,3 +15,8 @@ function sanitize_title($value)
 {
     return strtolower($value);
 }
+
+function get_row_layout()
+{
+    return 'text';
+}


### PR DESCRIPTION
This feature lets us write cleaner if-statements with layouts and flexible content in our templates.

```php
// Before
if (get_row_layout() === 'text') { ... }

// After
if (is_layout('text')) { ... }
```