### PR TITLE
Add custom keys support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added is layout helper function
 - Added sanitize key helper method
 - Added validate key helper method
+- Added prefix group, field and layout validation
 - Updated group key prefix sanitize
 - Updated key generation argument order
 - Updated key validation for fields without name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added sanitize key helper method
 - Added validate key helper method
 - Updated group key prefix sanitize
+- Updated key generation argument order
 - Updated key validation for fields without name
 - Updated project structure
 - Fixed clone field support

--- a/src/Attributes/Key.php
+++ b/src/Attributes/Key.php
@@ -41,7 +41,7 @@ class Key
     {
         $key = sprintf('%s_%s', $prefix, static::hash($key));
 
-        static::validate($key);
+        static::validate($key, $prefix);
 
         static::$keys[] = $key;
 
@@ -78,23 +78,20 @@ class Key
      * Validate a given key's uniqness.
      *
      * @param string $key
+     * @param string $prefix
      *
      * @throws \InvalidArgumentException
      *
      * @return string
      */
-    public static function validate(string $key): string
+    public static function validate(string $key, string $prefix): string
     {
         if (in_array($key, self::$keys)) {
             throw new InvalidArgumentException("The key [$key] is not unique.");
         }
 
-        if (
-            strpos($key, 'field') !== false &&
-            strpos($key, 'group') !== false &&
-            strpos($key, 'layout') !== false
-        ) {
-            throw new InvalidArgumentException('The key prefix must be either field, group or layout.');
+        if (strpos($key, $prefix) !== false) {
+            throw new InvalidArgumentException("The key must be prefixed with [$prefix].");
         }
 
         return $key;

--- a/src/Attributes/Key.php
+++ b/src/Attributes/Key.php
@@ -32,12 +32,12 @@ class Key
     /**
      * Generate a new field, group or layout key.
      *
-     * @param string $prefix
      * @param string $key
+     * @param string $prefix
      *
      * @return string
      */
-    public static function generate(string $prefix, string $key): string
+    public static function generate(string $key, string $prefix): string
     {
         $key = sprintf('%s_%s', $prefix, static::hash($key));
 

--- a/src/Attributes/Key.php
+++ b/src/Attributes/Key.php
@@ -90,7 +90,7 @@ class Key
             throw new InvalidArgumentException("The key [$key] is not unique.");
         }
 
-        if (strpos($key, $prefix) !== false) {
+        if (strpos($key, $prefix) === false) {
             throw new InvalidArgumentException("The key must be prefixed with [$prefix].");
         }
 

--- a/src/Attributes/Layout.php
+++ b/src/Attributes/Layout.php
@@ -24,20 +24,6 @@ use WordPlate\Acf\Field;
 class Layout extends Field
 {
     /**
-     * The parent field key.
-     *
-     * @var string
-     */
-    protected $parentKey;
-
-    /**
-     * The config repository.
-     *
-     * @var \WordPlate\Acf\Config\Repository
-     */
-    protected $config;
-
-    /**
      * Create a new layout instance.
      *
      * @param array $config
@@ -56,9 +42,25 @@ class Layout extends Field
      */
     public function getKey(): string
     {
-        $name = Key::sanitize($this->config->get('name'));
+        if ($this->key) {
+            return $this->key;
+        }
 
-        return sprintf('%s_%s', $this->parentKey, $name);
+        if ($this->config->has('key')) {
+            $key = Key::validate($this->config->get('key'), 'layout');
+
+            $this->key = $key;
+
+            return $this->key;
+        }
+
+        $this->key = printf(
+            '%s_%s',
+            $this->parentKey,
+            Key::sanitize($this->config->get('name'))
+        );
+
+        return $this->key;
     }
 
     /**
@@ -68,9 +70,11 @@ class Layout extends Field
      */
     public function toArray(): array
     {
-        $config = [
-            'key' => Key::generate('layout', $this->getKey()),
-        ];
+        $config = [];
+
+        if (!$this->config->has('key')) {
+            $config['key'] = Key::generate('layout', $this->getKey());
+        }
 
         if ($this->config->has('sub_fields')) {
             $config['sub_fields'] = $this->getSubFields();

--- a/src/Attributes/Layout.php
+++ b/src/Attributes/Layout.php
@@ -54,7 +54,7 @@ class Layout extends Field
             return $this->key;
         }
 
-        $this->key = printf(
+        $this->key = sprintf(
             '%s_%s',
             $this->parentKey,
             Key::sanitize($this->config->get('name'))

--- a/src/Attributes/Layout.php
+++ b/src/Attributes/Layout.php
@@ -73,7 +73,7 @@ class Layout extends Field
         $config = [];
 
         if (!$this->config->has('key')) {
-            $config['key'] = Key::generate('layout', $this->getKey());
+            $config['key'] = Key::generate($this->getKey(), 'layout');
         }
 
         if ($this->config->has('sub_fields')) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -180,7 +180,7 @@ class Field
         $config = [];
 
         if (!$this->config->has('key')) {
-            $config['key'] = Key::generate('field', $this->getKey());
+            $config['key'] = Key::generate($this->getKey(), 'field');
         }
 
         if ($this->config->has('conditional_logic')) {

--- a/src/Field.php
+++ b/src/Field.php
@@ -71,14 +71,16 @@ class Field
             return $this->key;
         }
 
+        // If the user has set a custom key.
         if ($this->config->has('key')) {
-            $key = Key::validate($this->config->get('key'));
+            $key = Key::validate($this->config->get('key'), 'field');
 
             $this->key = $key;
 
             return $key;
         }
 
+        // For fields which doesn't require name attribute we use label instead.
         if (in_array($this->getType(), ['accordion', 'message', 'tab'])) {
             $key = $this->config->get('label');
         } else {

--- a/src/Field.php
+++ b/src/Field.php
@@ -80,7 +80,7 @@ class Field
             return $key;
         }
 
-        // For fields which doesn't require name attribute we use label instead.
+        // For fields which doesn't require name attribute use label instead.
         if (in_array($this->getType(), ['accordion', 'message', 'tab'])) {
             $key = $this->config->get('label');
         } else {
@@ -179,7 +179,9 @@ class Field
     {
         $config = [];
 
-        if (!$this->config->has('key')) {
+        if ($this->config->has('key')) {
+            Key::validate($this->config->get('key'), 'field');
+        } else {
             $config['key'] = Key::generate($this->getKey(), 'field');
         }
 

--- a/src/Field.php
+++ b/src/Field.php
@@ -180,7 +180,7 @@ class Field
         $config = [];
 
         if ($this->config->has('key')) {
-            Key::validate($this->config->get('key'), 'field');
+            $config['key'] = $this->getKey();
         } else {
             $config['key'] = Key::generate($this->getKey(), 'field');
         }

--- a/src/Group.php
+++ b/src/Group.php
@@ -102,7 +102,9 @@ class Group
             'fields' => $this->getFields(),
         ];
 
-        if (!$this->config->has('key')) {
+        if ($this->config->has('key')) {
+            Key::validate($this->config->get('key'), 'group');
+        } else {
             $config['key'] = Key::generate($this->getKey(), 'group');
         }
 

--- a/src/Group.php
+++ b/src/Group.php
@@ -103,7 +103,7 @@ class Group
         ];
 
         if (!$this->config->has('key')) {
-            $config['key'] = Key::generate('group', $this->getKey());
+            $config['key'] = Key::generate($this->getKey(), 'group');
         }
 
         return array_merge($this->config->toArray(), $config);

--- a/src/Group.php
+++ b/src/Group.php
@@ -103,7 +103,7 @@ class Group
         ];
 
         if ($this->config->has('key')) {
-            Key::validate($this->config->get('key'), 'group');
+            $config['key'] = $this->getKey();
         } else {
             $config['key'] = Key::generate($this->getKey(), 'group');
         }

--- a/src/Group.php
+++ b/src/Group.php
@@ -50,24 +50,26 @@ class Group
     }
 
     /**
-     * Set the group key.
-     *
-     * @param string $key
-     *
-     * @return void
-     */
-    public function setKey(string $key): void
-    {
-        $this->key = Key::sanitize($key);
-    }
-
-    /**
      * Get the group key.
      *
      * @return string
      */
     public function getKey(): string
     {
+        if ($this->key) {
+            return $this->key;
+        }
+
+        if ($this->config->has('key')) {
+            $key = Key::validate($this->config->get('key'), 'group');
+
+            $this->key = $key;
+
+            return $key;
+        }
+
+        $this->key = Key::sanitize($this->config->get('title'));
+
         return $this->key;
     }
 
@@ -96,12 +98,13 @@ class Group
      */
     public function toArray(): array
     {
-        $key = Key::generate('group', $this->getKey());
-
         $config = [
-            'key' => $key,
             'fields' => $this->getFields(),
         ];
+
+        if (!$this->config->has('key')) {
+            $config['key'] = Key::generate('group', $this->getKey());
+        }
 
         return array_merge($this->config->toArray(), $config);
     }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -180,8 +180,6 @@ if (!function_exists('acf_field_group')) {
 
         $group = new Group($config);
 
-        $group->setKey($config['key'] ?? $config['title']);
-
         acf_add_local_field_group($group->toArray());
     }
 }

--- a/tests/Attributes/KeyTest.php
+++ b/tests/Attributes/KeyTest.php
@@ -33,15 +33,15 @@ class KeyTest extends TestCase
 
     public function testValidate()
     {
+        // $this->expectException(InvalidArgumentException::class);
+        // $this->expectExceptionMessage('The key [layout_2f1c419c] is not unique.');
+
+        $key = Key::generate('layout', 'block_video');
+
         $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The key [layout_2f1c419c] is not unique.');
+        $this->expectExceptionMessage('The key must be prefixed with [layout].');
 
-        Key::generate('layout', 'block_image');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('The key prefix must be either field, group or layout.');
-
-        Key::validate('image');
+        Key::validate('video', 'layout');
     }
 
     public function testSanitize()

--- a/tests/Attributes/KeyTest.php
+++ b/tests/Attributes/KeyTest.php
@@ -33,8 +33,8 @@ class KeyTest extends TestCase
 
     public function testValidate()
     {
-        // $this->expectException(InvalidArgumentException::class);
-        // $this->expectExceptionMessage('The key [layout_2f1c419c] is not unique.');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key [layout_2f1c419c] is not unique.');
 
         Key::generate('block_video', 'layout');
 

--- a/tests/Attributes/KeyTest.php
+++ b/tests/Attributes/KeyTest.php
@@ -26,7 +26,7 @@ class KeyTest extends TestCase
 {
     public function testGenerate()
     {
-        $key = Key::generate('layout', 'block_image');
+        $key = Key::generate('block_image', 'layout');
 
         $this->assertSame('layout_2f1c419c', $key);
     }
@@ -36,7 +36,7 @@ class KeyTest extends TestCase
         // $this->expectException(InvalidArgumentException::class);
         // $this->expectExceptionMessage('The key [layout_2f1c419c] is not unique.');
 
-        $key = Key::generate('layout', 'block_video');
+        Key::generate('block_video', 'layout');
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The key must be prefixed with [layout].');

--- a/tests/FieldTest.php
+++ b/tests/FieldTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace WordPlate\Tests\Acf;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use WordPlate\Acf\Field;
 
@@ -166,6 +167,17 @@ class FieldTest extends TestCase
             'key' => 'field_password',
             'type' => 'password',
         ], $field->toArray());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key must be prefixed with [field]');
+
+        $field = acf_password([
+            'name' => 'password',
+            'label' => 'Password',
+            'key' => 'password',
+        ]);
+
+        $field->toArray();
     }
 
     protected function getField()

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -58,13 +58,13 @@ class GroupTest extends TestCase
     public function testCustomKey()
     {
         $group = new Group([
-            'key' => 'image',
+            'key' => 'group_image',
             'title' => 'Image',
             'fields' => [],
         ]);
 
         $this->assertSame([
-            'key' => 'image',
+            'key' => 'group_image',
             'title' => 'Image',
             'fields' => [],
         ], $group->toArray());

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -68,6 +68,17 @@ class GroupTest extends TestCase
             'title' => 'Image',
             'fields' => [],
         ], $group->toArray());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('The key must be prefixed with [group]');
+
+        $group = new Group([
+            'key' => 'employee',
+            'title' => 'Employee',
+            'fields' => [],
+        ]);
+
+        $group->toArray();
     }
 
     /**

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -60,7 +60,7 @@ class GroupTest extends TestCase
         $group = new Group([
             'key' => 'image',
             'title' => 'Image',
-            'fields' => []
+            'fields' => [],
         ]);
 
         $this->assertSame([

--- a/tests/GroupTest.php
+++ b/tests/GroupTest.php
@@ -37,18 +37,6 @@ class GroupTest extends TestCase
     /**
      * @runInSeparateProcess
      */
-    public function testSetKey()
-    {
-        $group = $this->getGroup();
-
-        $group->setKey('event');
-
-        $this->assertSame('event', $group->getKey());
-    }
-
-    /**
-     * @runInSeparateProcess
-     */
     public function testGetFields()
     {
         $group = $this->getGroup();
@@ -59,6 +47,29 @@ class GroupTest extends TestCase
         $this->assertSame('text', $fields[0]['type']);
     }
 
+    public function testGroupMissingTitleKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing setting key [title].');
+
+        new Group(['key' => 'without_title']);
+    }
+
+    public function testCustomKey()
+    {
+        $group = new Group([
+            'key' => 'image',
+            'title' => 'Image',
+            'fields' => []
+        ]);
+
+        $this->assertSame([
+            'key' => 'image',
+            'title' => 'Image',
+            'fields' => [],
+        ], $group->toArray());
+    }
+
     /**
      * @runInSeparateProcess
      */
@@ -67,7 +78,6 @@ class GroupTest extends TestCase
         $group = $this->getGroup();
 
         $this->assertSame([
-            'key' => 'group_13b71421',
             'title' => 'Employee',
             'fields' => [
                 [
@@ -77,28 +87,18 @@ class GroupTest extends TestCase
                     'key' => 'field_63445d8e',
                 ],
             ],
+            'key' => 'group_13b71421',
         ], $group->toArray());
-    }
-
-    public function testGroupMissingTitleKey()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Missing setting key [title].');
-
-        new Group(['key' => 'without_title']);
     }
 
     protected function getGroup()
     {
         $group = new Group([
-            'key' => 'employee',
             'title' => 'Employee',
             'fields' => [
                 acf_text(['label' => 'First Name', 'name' => 'first_name']),
             ],
         ]);
-
-        $group->setKey('employee');
 
         return $group;
     }


### PR DESCRIPTION
This pull request adds support for custom field keys. Currently we're creating the keys based on parent field/group and the name value. With custom keys we can take leverage of the `acf_clone` function and actually make it work.

This is still very much work in progress.