### PR TITLE
Added acf_clone example

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ acf_accordion([
 
 ```php
 acf_text([
-        'key' => 'field_nameInput',
+        'key' => 'field_name',
         'label' => 'Name',
         'name' => 'name',
         'placeholder' => 'Enter name here',
@@ -440,7 +440,7 @@ acf_text([
         'label' => 'NameClone',
         'name' => 'nameClone',
         'clone' => [
-            'field_nameInput',
+            'field_name',
             // This is the key of the field or group we want to clone. In this basic example the only settings that will be copied is the placeholder.
         ],
     ]),

--- a/README.md
+++ b/README.md
@@ -427,10 +427,22 @@ acf_accordion([
 ]),
 ```
 
-**Clone** - The [clone field](https://www.advancedcustomfields.com/resources/clone) allows you to select and display existing fields.
+**Clone** - The [clone field](https://www.advancedcustomfields.com/resources/clone) allows you to select and display existing fields or groups.
 
 ```php
-// TODO: Add acf_clone function example.
+acf_text([
+	'label' => 'name',
+	'name' => 'Name',
+	'placeholder' => 'Enter name here',
+]),
+acf_clone([
+	'label' => 'nameClone',
+	'name' => 'Name',
+	'clone' => [
+		0 => 'field_f1fab926', 
+		// This is the key of the field or group we want to clone. We can get the key by right clicking the field/group in the administrator dashboard and inspecting the element. In this basic example the only settings that will be copied is the placeholder.
+	],
+]),
 ```
 
 **Flexible Content** - The [flexible content field](https://www.advancedcustomfields.com/resources/flexible-content) acts as a blank canvas to which you can add an unlimited number of [layouts](#layout) with full control over the order.

--- a/README.md
+++ b/README.md
@@ -431,17 +431,19 @@ acf_accordion([
 
 ```php
 acf_text([
-	'label' => 'name',
-	'name' => 'Name',
-	'placeholder' => 'Enter name here',
-]),
-acf_clone([
-	'label' => 'nameClone',
-	'name' => 'Name',
-	'clone' => [
-		0 => 'field_f1fab926', 
-		// This is the key of the field or group we want to clone. We can get the key by right clicking the field/group in the administrator dashboard and inspecting the element. In this basic example the only settings that will be copied is the placeholder.
-	],
+        'key' => 'field_nameInput',
+        'label' => 'Name',
+        'name' => 'name',
+        'placeholder' => 'Enter name here',
+    ]),
+    acf_clone([
+        'label' => 'NameClone',
+        'name' => 'nameClone',
+        'clone' => [
+            'field_nameInput',
+            // This is the key of the field or group we want to clone. In this basic example the only settings that will be copied is the placeholder.
+        ],
+    ]),
 ]),
 ```
 


### PR DESCRIPTION
Added acf_clone example. Tried to create the key myself on the original text input, that didn't work so I put the way I got the field key in a comment next to it.