### PR TITLE
Fix field() for null $post and non sub fields

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -669,7 +669,7 @@ if (!function_exists('field')) {
         if ($post) {
             $value = get_field($name, $post);
         } else {
-            $value = get_sub_field($name) ?? get_field($name);
+            $value = get_sub_field($name) ?: get_field($name);
         }
 
         return empty($value) ? null : $value;


### PR DESCRIPTION
Fixes: If get_sub_field($name) returns false, this function would also return false.