### PR TITLE
Add ability to disallow archives for PageLink field

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ use WordPlate\Acf\Fields\PageLink;
 PageLink::make('Contact Link')
     ->postTypes(['contact'])
     ->taxonomies(['category:city'])
-    ->allowArchives()
+    ->allowArchives() // optionally pass 'false' to disallow archives
     ->allowNull()
     ->allowMultiple()
     ->required();

--- a/src/Fields/PageLink.php
+++ b/src/Fields/PageLink.php
@@ -36,9 +36,12 @@ class PageLink extends Field
      */
     protected $type = 'page_link';
 
-    public function allowArchives(): self
+    /**
+     * @param bool|null $value
+     */
+    public function allowArchives(?bool $value = null): self
     {
-        $this->config->set('allow_archives', true);
+        $this->config->set('allow_archives', $value ?? true);
 
         return $this;
     }

--- a/src/Fields/PageLink.php
+++ b/src/Fields/PageLink.php
@@ -36,12 +36,9 @@ class PageLink extends Field
      */
     protected $type = 'page_link';
 
-    /**
-     * @param bool|null $value
-     */
-    public function allowArchives(?bool $value = null): self
+    public function allowArchives(bool $value = true): self
     {
-        $this->config->set('allow_archives', $value ?? true);
+        $this->config->set('allow_archives', $value);
 
         return $this;
     }

--- a/tests/Fields/PageLinkTest.php
+++ b/tests/Fields/PageLinkTest.php
@@ -29,4 +29,10 @@ class PageLinkTest extends TestCase
         $field = PageLink::make('Page Link Archives')->allowArchives()->toArray();
         $this->assertTrue($field['allow_archives']);
     }
+
+    public function testDisallowArchives()
+    {
+        $field = PageLink::make('Page Link Non-archives')->allowArchives(false)->toArray();
+        $this->assertFalse($field['allow_archives']);
+    }
 }


### PR DESCRIPTION
I noticed that by default the "allow_archives" setting of the ACF Page Link field type is set to true. Because of this, the WordPlate Page Link field's "allowArchives" method is essentially redundant, and doesn't allow us to modify the default ACF behavior. It seems like ACF's behavior is inconsistent with their typical conventions in this case.

## Proposed Changes

  - Add the ability to pass a boolean to "allowArchives" to allow the setting to be overridden, while maintaining backwards compatibility with previous versions. 
  - We could alternatively add a "disallowArchives" method but it seemed to defy conventions.
